### PR TITLE
Use ionide api

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,14 @@
 			"name": "Launch",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
-			"args": ["${workspaceRoot}/demo", "--extensionDevelopmentPath=${workspaceRoot}/release" ],
+			"args": [
+				"${workspaceRoot}/demo",
+				"--extensionDevelopmentPath=${workspaceRoot}/release"
+			],
 			"stopOnEntry": false,
 			"request": "launch",
-			"sourceMaps": false
+			"sourceMaps": false,
+			"preLaunchTask": "Build"
 		}
 	]
 }

--- a/release/package.json
+++ b/release/package.json
@@ -23,5 +23,8 @@
     "outputChannels": [
       "Mechanic"
     ]
-  }
+  },
+  "extensionDependencies": [
+    "Ionide.Ionide-fsharp"
+  ]
 }

--- a/src/Model.fs
+++ b/src/Model.fs
@@ -1,0 +1,40 @@
+module Model
+
+type ProjectFilePath = string
+type SourceFilePath = string
+type ProjectReferencePath = string
+
+[<RequireQualifiedAccess>]
+type ProjectResponseInfo =
+    | DotnetSdk of ProjectResponseInfoDotnetSdk
+    | Verbose
+    | ProjectJson
+
+and ProjectResponseInfoDotnetSdk = {
+    IsTestProject: bool
+    Configuration: string
+    IsPackable: bool
+    TargetFramework: string
+    TargetFrameworkIdentifier: string
+    TargetFrameworkVersion: string
+    RestoreSuccess: bool
+    TargetFrameworks: string list
+    RunCmd: RunCmd option
+    IsPublishable: bool option }
+
+and [<RequireQualifiedAccess>] RunCmd = { Command: string; Arguments: string }
+
+type Project = {
+    Project: ProjectFilePath
+    Files: SourceFilePath list
+    Output: string
+    References: ProjectReferencePath list
+    Logs: Map<string, string>
+    OutputType: string
+    Info: ProjectResponseInfo
+    AdditionalInfo: Map<string, string>
+}
+
+type IonideApi = {
+    ProjectLoadedEvent: Event<Project>
+}

--- a/src/VSCode.Mechanic.fsproj
+++ b/src/VSCode.Mechanic.fsproj
@@ -11,6 +11,7 @@
     <None Include="paket.references" />
     <Compile Include="Helpers.fs" />
     <Compile Include="Cli.fs" />
+    <Compile Include="Model.fs" />
     <Compile Include="Mechanic.fs" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />


### PR DESCRIPTION
Adds integration with Ionide-fsharp to get list of projects instead of finding them manually. Thanks to that we have access to full information about the projects, which enables us to detection project to which current file belongs etc.